### PR TITLE
fix: remove header, fix layout files

### DIFF
--- a/app/(auth-pages)/layout.tsx
+++ b/app/(auth-pages)/layout.tsx
@@ -1,9 +1,20 @@
+import Link from "next/link";
+
 export default async function Layout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="max-w-7xl flex flex-col gap-12 items-start">{children}</div>
+    <div className="flex-1 w-full flex flex-col items-center">
+      <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
+        <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
+          <div className="flex gap-5 items-center font-semibold">
+            <Link href="/">Bruhspence</Link>
+          </div>
+        </div>
+      </nav>
+      <main className="mt-24"> {children}</main>
+    </div>
   );
 }

--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -12,7 +12,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
     <form className="flex-1 flex flex-col min-w-64">
       <h1 className="text-2xl font-medium">Sign in</h1>
       <p className="text-sm text-foreground">
-        Don't have an account?
+        Don't have an account?{" "}
         <Link className="text-foreground font-medium underline" href="/sign-up">
           Sign up
         </Link>

--- a/app/(auth-pages)/sign-up/page.tsx
+++ b/app/(auth-pages)/sign-up/page.tsx
@@ -19,33 +19,32 @@ export default async function Signup(props: {
   }
 
   return (
-    <>
-      <form className="flex flex-col min-w-64 max-w-64 mx-auto">
-        <h1 className="text-2xl font-medium">Sign up</h1>
-        <p className="text-sm text text-foreground">
-          Already have an account?{" "}
-          <Link className="text-primary font-medium underline" href="/sign-in">
-            Sign in
-          </Link>
-        </p>
-        <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
-          <Label htmlFor="email">Email</Label>
-          <Input name="email" placeholder="you@example.com" required />
-          <Label htmlFor="password">Password</Label>
-          <Input
-            type="password"
-            name="password"
-            placeholder="Your password"
-            minLength={6}
-            required
-          />
-          <SubmitButton formAction={signUpAction} pendingText="Signing up...">
-            Sign up
-          </SubmitButton>
-          <FormMessage message={searchParams} />
-          <Googlebutton />
-        </div>
-      </form>
-    </>
+    <form className="flex flex-col min-w-64 max-w-64 mx-auto">
+      <h1 className="text-2xl font-medium">Sign up</h1>
+      <p className="text-sm text text-foreground">
+        Already have an account?{" "}
+        <Link className="text-primary font-medium underline" href="/sign-in">
+          Sign in
+        </Link>
+      </p>
+      <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
+        <Label htmlFor="email">Email</Label>
+        <Input name="email" placeholder="you@example.com" required />
+        <Label htmlFor="password">Password</Label>
+        <Input
+          type="password"
+          name="password"
+          placeholder="Your password"
+          minLength={6}
+          required
+        />
+
+        <SubmitButton formAction={signUpAction} pendingText="Signing up...">
+          Sign up
+        </SubmitButton>
+        <FormMessage message={searchParams} />
+        <Googlebutton />
+      </div>
+    </form>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,26 +35,19 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <main className="min-h-screen flex flex-col items-center">
-            <div className="flex-1 w-full flex flex-col gap-20 items-center">
-              <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
-                <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
-                  <div className="flex gap-5 items-center font-semibold">
-                    <Link href={"/"}>Bruhspence</Link>
-                  </div>
-                  <HeaderAuth />
-                </div>
-              </nav>
-              <div className="flex flex-col gap-20 max-w-5xl p-5">
+          <div className="min-h-screen flex flex-col">
+            <main className="flex-1 w-full flex flex-col items-center">
+              <div className="flex-1 w-full flex flex-col items-center">
                 {children}
               </div>
-
-              <footer className="w-full flex items-center justify-center border-t mx-auto text-center text-xs gap-8 py-16">
+            </main>
+            <footer className="w-full border-t">
+              <div className="flex items-center justify-center gap-8 py-4 text-xs">
                 <p>Powered by the will to survive</p>
                 <ThemeSwitcher />
-              </footer>
-            </div>
-          </main>
+              </div>
+            </footer>
+          </div>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,18 @@
+import Link from "next/link";
+import HeaderAuth from "@/components/header-auth";
 export default async function Home() {
   return (
     <>
+      <div className="flex-1 w-full flex flex-col items-center">
+        <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
+          <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
+            <div className="flex gap-5 items-center font-semibold">
+              Bruhspence
+            </div>
+            <HeaderAuth />
+          </div>
+        </nav>
+      </div>
       <main className="flex-1 flex flex-col gap-6 px-4">Hello world</main>
     </>
   );

--- a/components/ui/app-sidebar.tsx
+++ b/components/ui/app-sidebar.tsx
@@ -1,15 +1,30 @@
-import { Calendar, Home, Inbox, Search, Settings } from "lucide-react"
+import { signOutAction } from "@/app/actions";
+import {
+  Calendar,
+  ChevronUp,
+  Home,
+  Inbox,
+  Search,
+  Settings,
+} from "lucide-react";
 
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@/components/ui/sidebar"
+} from "@/components/ui/sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@radix-ui/react-dropdown-menu";
 
 // Menu items.
 const items = [
@@ -38,7 +53,7 @@ const items = [
     url: "#",
     icon: Settings,
   },
-]
+];
 
 export function AppSidebar() {
   return (
@@ -62,6 +77,34 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton>
+                  Username
+                  <ChevronUp className="ml-auto" />
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                side="top"
+                className="w-[--radix-popper-anchor-width]"
+              >
+                <DropdownMenuItem>
+                  <span>Account</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <span>Billing</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={signOutAction}>
+                  <span>Sign out</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
     </Sidebar>
-  )
+  );
 }


### PR DESCRIPTION
## Describe your changes
Fixed the layout for the shared landing pages & protected pages.
* When the user logs in they no longer see the header, but on "/" and auth pages, they will see the header. 
* Clicking on "bruhspence" will take user to "/"
* Users can logout with dropdown at the bottom of the sidebar

## Issue ticket number and link
#11 Remove header

## TODO
- [x] run `npm run build` to check if it will pass vercel type checks
- [x] run `npm run format` to lint the app
- [x] What else does this need? 
